### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/cloudformation/hids-cwl-es.template
+++ b/cloudformation/hids-cwl-es.template
@@ -494,7 +494,7 @@ Resources:
               Fn::GetAtt:
                 - "HIDSLambdaRole"
                 - "Arn"
-            Runtime : "nodejs8.10"
+            Runtime : "nodejs10.x"
             Environment:
               Variables:
                 ES_ENDPOINT: !GetAtt HIDSESDomain.DomainEndpoint


### PR DESCRIPTION
CloudFormation templates in hids-cloudwatchlogs-elasticsearch-template have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.